### PR TITLE
Record excel files reading in DB

### DIFF
--- a/sas_select/__init__.py
+++ b/sas_select/__init__.py
@@ -69,7 +69,7 @@ def create_app(test_config=None):
 
         else:
             products = None
-        return render_template('listproducts.html', products=products, page_title="Products in database", frm=request.form)
+        return render_template('listproducts.html', products=products, page_title="Products in database", frm=request.form, excel=datasheet.find_last_file_name())
 
     def pack_entitlement(product):
         pack_size = product["PackSize"]
@@ -113,18 +113,18 @@ def create_app(test_config=None):
             abort(404)
         qty = pack_entitlement(product)
         # print(qty)
-        return render_template('viewproduct.html', product=product, page_title="View product", pack_entitlement=qty)
+        return render_template('viewproduct.html', product=product, page_title="View product", pack_entitlement=qty, excel=datasheet.find_last_file_name())
     db.init_app(app)
 
     @app.route('/init-db')
     def init_db():
         try:
-            datasheet.init_db()
+            message = datasheet.init_db()
+            print(message)
+            flash(message, 'success')
         except ValueError as err:
             print(err.args[0], err.args[1])
             flash(err.args[0], 'error')
-        else:
-            flash('Database updated', 'success')
         return redirect(url_for('view_products'))
 
     @app.template_filter()

--- a/sas_select/__init__.py
+++ b/sas_select/__init__.py
@@ -116,10 +116,10 @@ def create_app(test_config=None):
         return render_template('viewproduct.html', product=product, page_title="View product", pack_entitlement=qty)
     db.init_app(app)
 
-    @app.route('/init-db')
-    def init_db():
+    @app.route('/fetch-data')
+    def fetch_data():
         try:
-            message = datasheet.init_db()
+            message = datasheet.fetch_data()
             print(message)
             flash(message, 'success')
         except ValueError as err:

--- a/sas_select/__init__.py
+++ b/sas_select/__init__.py
@@ -69,7 +69,7 @@ def create_app(test_config=None):
 
         else:
             products = None
-        return render_template('listproducts.html', products=products, page_title="Products in database", frm=request.form, excel=datasheet.find_last_file_name())
+        return render_template('listproducts.html', products=products, page_title="Products in database", frm=request.form)
 
     def pack_entitlement(product):
         pack_size = product["PackSize"]
@@ -113,7 +113,7 @@ def create_app(test_config=None):
             abort(404)
         qty = pack_entitlement(product)
         # print(qty)
-        return render_template('viewproduct.html', product=product, page_title="View product", pack_entitlement=qty, excel=datasheet.find_last_file_name())
+        return render_template('viewproduct.html', product=product, page_title="View product", pack_entitlement=qty)
     db.init_app(app)
 
     @app.route('/init-db')
@@ -135,6 +135,10 @@ def create_app(test_config=None):
             return '${:,.2f}'.format(price)
         else:
             return '-${:,.2f}'.format(abs(price))
+
+    @app.context_processor
+    def inject_excel_file_name():
+        return dict(excel=datasheet.find_last_file_name())
 
     return app
 

--- a/sas_select/datasheet.py
+++ b/sas_select/datasheet.py
@@ -83,7 +83,11 @@ def init_db():
 
     if scrape_page:
         new_url = find_xl_url()
-        file_name = re.search(r'([^/]+)(?=\.\w+$)', new_url).group(0)
+        regex = r'([^\/]+)(?=\.\w+$)'
+        # This regex is to find excel file name from end of url excluding final .xls or .xlsx
+        # ([^\/]+) : Find group of characters not including forward slash
+        # (?=.\w+$) : look ahead to find a dot, followed by a word, followed by end of line and exclude this whole part.
+        file_name = re.search(regex, new_url).group(0)
         sas_db = db.get_db()
 
         if last_reading and new_url == last_reading['FileURL']:

--- a/sas_select/datasheet.py
+++ b/sas_select/datasheet.py
@@ -76,7 +76,7 @@ def populate_db_from_df(df):
     sas_db.commit()
 
 
-def init_db():
+def fetch_data():
     """Read excel file from gov website, check required columns exist, empty and repopulate database"""
 
     scrape_page, last_reading = need_scrape()

--- a/sas_select/db.py
+++ b/sas_select/db.py
@@ -31,8 +31,16 @@ def empty_tbl_products():
         db.executescript(f.read().decode('utf8'))
 
 
+def empty_tbl_data_reading():
+    db = get_db()
+
+    with current_app.open_resource('schema_tbl_data_reading.sql') as f:
+        db.executescript(f.read().decode('utf8'))
+
+
 def init_db():
     empty_tbl_products()
+    empty_tbl_data_reading()
 
 
 @click.command('init-db')

--- a/sas_select/schema_tbl_data_reading.sql
+++ b/sas_select/schema_tbl_data_reading.sql
@@ -1,7 +1,7 @@
 BEGIN TRANSACTION;
 DROP TABLE IF EXISTS tbl_data_reading;
 CREATE TABLE tbl_data_reading (
-    ID integer primary key autoincrement,
+    ID integer primary key,
     FileURL varchar,
     FileName varchar,
     ReadDate timestamp,

--- a/sas_select/schema_tbl_data_reading.sql
+++ b/sas_select/schema_tbl_data_reading.sql
@@ -1,0 +1,10 @@
+BEGIN TRANSACTION;
+DROP TABLE IF EXISTS tbl_data_reading;
+CREATE TABLE tbl_data_reading (
+    ID integer primary key autoincrement,
+    FileURL varchar,
+    FileName varchar,
+    ReadDate timestamp,
+    LastScrapeDate timestamp
+);
+COMMIT;

--- a/sas_select/templates/layout.html
+++ b/sas_select/templates/layout.html
@@ -17,6 +17,6 @@
     {% endfor %}
     <div id="page_content">{% block page_content %}{% endblock %}
     </div>
-<footer>Software provided by bpss. Version {{ version }}</footer>
+<footer>Software provided by bpss. Version {{ version }}. Database {{ excel }}</footer>
 {% endblock %}
 


### PR DESCRIPTION
Fixes issue #40.

Please note that excel version is read from database every time `listproducts.html` or `viewproduct.html` is rendered.

Maybe in the future we could add a file in instance path to keep the latest excel file name and scrape date so the templates can read from it rather than from the database. Then, update the file when a new scrape is made.